### PR TITLE
Removed ProjectionTable from Projection.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,6 @@ pomExtra := <developers>
 val AkkaVersion = "2.6.20"
 val ScalaTestVersion = "3.2.12"
 val DoobieVersion = "1.0.0-RC2"
-val circeVersion = "0.14.1"
 
 val DamlVersion = "2.5.0-snapshot.20221120.10983.0.218a6a8a"
 
@@ -46,9 +45,6 @@ val deps = Seq(
   "com.daml" % "bindings-java" % DamlVersion,
   "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
   "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-  "io.circe" %% "circe-core" % circeVersion,
-  "io.circe" %% "circe-generic" % circeVersion,
-  "io.circe" %% "circe-parser" % circeVersion,
   "org.flywaydb" % "flyway-core" % "8.5.11",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
   "com.zaxxer" % "HikariCP" % "5.0.1" % Test,
@@ -63,7 +59,6 @@ val deps = Seq(
   "org.tpolecat" %% "doobie-postgres" % DoobieVersion % Test,
   "org.tpolecat" %% "doobie-core" % DoobieVersion % Test,
   "org.tpolecat" %% "doobie-hikari" % DoobieVersion % Test,
-  "org.tpolecat" %% "doobie-postgres-circe" % DoobieVersion % Test,
   "com.daml" % "bindings-rxjava" % DamlVersion % Test,
   ("com.daml" %% "sandbox-on-x" % DamlVersion % Test).exclude("org.slf4j", "slf4j-api")
 )

--- a/src/main/resources/db/migration/projection/V1__create_schema.sql
+++ b/src/main/resources/db/migration/projection/V1__create_schema.sql
@@ -2,9 +2,6 @@
 CREATE TABLE ${projection_table_name}
 (
   "id"                TEXT        NOT NULL,
-  "projection_table"  TEXT        NOT NULL,
-  "data"              JSON        NOT NULL,
-  "projection_type"   TEXT        NOT NULL,
   "projection_offset" TEXT        NULL
 );
 

--- a/src/main/scala/com/daml/projection/ConsumerRecord.scala
+++ b/src/main/scala/com/daml/projection/ConsumerRecord.scala
@@ -54,15 +54,13 @@ object Envelope {
       workflowId: java.util.Optional[String],
       ledgerEffectiveTime: java.util.Optional[Instant],
       transactionId: java.util.Optional[String],
-      offset: java.util.Optional[Offset],
-      table: ProjectionTable
+      offset: java.util.Optional[Offset]
   ) = Envelope(
     event,
     OptionConverters.toScala(workflowId),
     OptionConverters.toScala(ledgerEffectiveTime),
     OptionConverters.toScala(transactionId),
-    OptionConverters.toScala(offset),
-    table
+    OptionConverters.toScala(offset)
   )
 }
 
@@ -74,8 +72,7 @@ final case class Envelope[T](
     workflowId: Option[String],
     ledgerEffectiveTime: Option[Instant],
     transactionId: Option[String],
-    offset: Option[Offset],
-    table: ProjectionTable
+    offset: Option[Offset]
 ) extends ConsumerRecord[T] {
 
   /** Returns the wrapped value */
@@ -88,7 +85,7 @@ final case class Envelope[T](
    * Maps the event, returning an envelope with an event as the result of `f`, keeping all other fields.
    */
   def map[B](f: T => B): Envelope[B] =
-    Envelope[B](f(event), workflowId, ledgerEffectiveTime, transactionId, offset, table)
+    Envelope[B](f(event), workflowId, ledgerEffectiveTime, transactionId, offset)
 
   /**
    * applies the partial function `f` to the wrapped event, returns some envelope with the result of the function (if
@@ -124,11 +121,4 @@ final case class Envelope[T](
    * Gets the [[Offset]]
    */
   def getOffset(): java.util.Optional[Offset] = OptionConverters.toJava(offset)
-
-  /**
-   * Java API
-   *
-   * Gets the [[ProjectionTable]]
-   */
-  def getProjectionTable(): ProjectionTable = table
 }

--- a/src/main/scala/com/daml/projection/JdbcProjector.scala
+++ b/src/main/scala/com/daml/projection/JdbcProjector.scala
@@ -115,8 +115,9 @@ object JdbcProjector {
           ExecuteUpdate
             .create(sql)
             .bind(1, projection.id.value)
-            .bind(2, projection.table.name)
-            .bind(3, "{}")
+            // TODO FIX ProjectionTable
+            .bind(2, "") // projection.table.name)
+            .bind(3, "{}") // TODO ProjectionSchema
             .bind(4, projection.getClass.getName),
           // rollback automatically starts a new tx
           _ => Rollback

--- a/src/main/scala/com/daml/projection/JdbcProjector.scala
+++ b/src/main/scala/com/daml/projection/JdbcProjector.scala
@@ -97,15 +97,9 @@ object JdbcProjector {
           s"""
           | insert into $projectionTableName(
           |   id,
-          |   projection_table,
-          |   data,
-          |   projection_type,
           |   projection_offset
           | )
           | values (
-          |   ?,
-          |   ?,
-          |   ?::jsonb,
           |   ?,
           |   NULL
           | )
@@ -114,11 +108,7 @@ object JdbcProjector {
         val insertIfNotExists = HandleError(
           ExecuteUpdate
             .create(sql)
-            .bind(1, projection.id.value)
-            // TODO FIX ProjectionTable
-            .bind(2, "") // projection.table.name)
-            .bind(3, "{}") // TODO ProjectionSchema
-            .bind(4, projection.getClass.getName),
+            .bind(1, projection.id.value),
           // rollback automatically starts a new tx
           _ => Rollback
         )

--- a/src/main/scala/com/daml/projection/Offset.scala
+++ b/src/main/scala/com/daml/projection/Offset.scala
@@ -4,8 +4,6 @@
 package com.daml.projection
 
 import com.daml.ledger.api.v1.ledger_offset.LedgerOffset
-import io.circe._
-import io.circe.generic.semiauto._
 
 /**
  * Creates [[Offset]]s
@@ -17,8 +15,6 @@ object Offset {
   private def mkProtoOffset(offset: Offset) = LedgerOffset(
     LedgerOffset.Value.Absolute(offset.value)
   )
-  implicit val `offset decoder`: Decoder[Offset] = deriveDecoder[Offset]
-  implicit val `offset encoder`: Encoder[Offset] = deriveEncoder[Offset]
 }
 
 /**

--- a/src/main/scala/com/daml/projection/Projection.scala
+++ b/src/main/scala/com/daml/projection/Projection.scala
@@ -197,7 +197,7 @@ object Projection extends {
       projection: Projection[Event],
       fc: Project[CreatedEvent, A],
       fa: Project[ArchivedEvent, A])(implicit sys: ActorSystem): scaladsl.Control =
-    project(batchSource, projection)(Projection.fromCreateOrArchive(fc, fa))
+    project(batchSource, projection)(Projection.fromCreatedOrArchived(fc, fa))
 
   private def run[A: Projector](source: Source[A, scaladsl.Control])(implicit sys: ActorSystem): scaladsl.Control = {
     source.viaMat(implicitly[Projector[A]].flow) { (sourceControl, projectorResource) =>
@@ -226,10 +226,10 @@ object Projection extends {
   }
 
   /**
-   * creates an `Event` Project function from a `CreatedEvent` [[Project]] function and a a `ArchivedEvent` [[Project]]
+   * creates an `Event` Project function from a `CreatedEvent` [[Project]] function and an `ArchivedEvent` [[Project]]
    * function
    */
-  def fromCreateOrArchive[A](
+  def fromCreatedOrArchived[A](
       fc: Project[CreatedEvent, A],
       fa: Project[ArchivedEvent, A]): Project[Event, A] = envelope => {
     val res = envelope.event.event match {

--- a/src/test/java/com/daml/projectiontest/JavaApiExample.java
+++ b/src/test/java/com/daml/projectiontest/JavaApiExample.java
@@ -13,9 +13,7 @@ import com.daml.quickstart.iou.iou.Iou;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
-import java.io.PrintWriter;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 
 /*
@@ -45,7 +43,7 @@ public class JavaApiExample {
       // A projection is automatically updated and resumed, if it is found in the projection table.
       // if bad data is encountered, the projection does not continue.
       var events =
-          Projection.<Event>create(new ProjectionId("iou-projection-for-party"), ProjectionFilter.parties(Set.of(partyId)), projectionTable)
+          Projection.<Event>create(new ProjectionId("iou-projection-for-party"), ProjectionFilter.parties(Set.of(partyId)))
               .withBatchSize(batchSize);
       Project<Event, JdbcAction> f =
           envelope -> {
@@ -55,7 +53,7 @@ public class JavaApiExample {
               var action =
                   ExecuteUpdate.create(
                           "insert into "
-                              + envelope.getProjectionTable().getName()
+                              + projectionTable.getName()
                               + "(contract_id, event_id, amount, currency) "
                               + "values (?, ?, ?, ?)")
                       .bind(1, event.getContractId())
@@ -67,7 +65,7 @@ public class JavaApiExample {
               var action =
                   ExecuteUpdate.create(
                           "delete from " +
-                              envelope.getProjectionTable().getName() +
+                              projectionTable.getName() +
                               " where contract_id = ?"
                       )
                       .bind(1, event.getContractId());
@@ -80,13 +78,13 @@ public class JavaApiExample {
       var control = projector.project(source, events, f);
       control.cancel();
 
-      var contracts = Projection.<Iou.Contract>create(new ProjectionId("id"), ProjectionFilter.parties(Set.of(partyId)), projectionTable);
+      var contracts = Projection.<Iou.Contract>create(new ProjectionId("id"), ProjectionFilter.parties(Set.of(partyId)));
       Project<Iou.Contract, JdbcAction> fc =
           envelope -> {
             var iou = envelope.getEvent();
             var action = ExecuteUpdate.create(
                     "insert into "
-                        + envelope.getProjectionTable().getName()
+                        + projectionTable.getName()
                         + "(contract_id, event_id, amount, currency) "
                         + "values (?, ?, ?, ?)")
                 .bind(1, iou.id.contractId)

--- a/src/test/scala/com/daml/projection/BatcherSpec.scala
+++ b/src/test/scala/com/daml/projection/BatcherSpec.scala
@@ -32,7 +32,7 @@ class BatcherSpec
       def assertBatches(batchSize: Int, nrBatches: Int) = {
         val envelopes =
           (0 until batchSize * nrBatches)
-            .map(i => Envelope(i, None, None, None, projection.offset, projection.table))
+            .map(i => Envelope(i, None, None, None, projection.offset))
             .toVector
         val probe =
           Source(envelopes).via(Batcher(batchSize, interval)).toMat(TestSink.probe)(Keep.right).run()
@@ -64,7 +64,7 @@ class BatcherSpec
         events.flatMap { i =>
           val offset = Offset(s"$i")
           List(
-            Envelope(i, None, None, None, projection.offset, projection.table),
+            Envelope(i, None, None, None, projection.offset),
             TxBoundary[Int](projection.id, offset)
           )
         }
@@ -111,7 +111,7 @@ class BatcherSpec
         events.flatMap { i =>
           val offset = Offset(s"$i")
           List(
-            Envelope(i, None, None, None, projection.offset, projection.table),
+            Envelope(i, None, None, None, projection.offset),
             TxBoundary[Int](projection.id, offset)
           )
         }
@@ -152,7 +152,7 @@ class BatcherSpec
         events.flatMap { i =>
           val offset = Offset(s"$i")
           List(
-            Envelope(i, None, None, None, projection.offset, projection.table),
+            Envelope(i, None, None, None, projection.offset),
             TxBoundary[Int](projection.id, offset)
           )
         }

--- a/src/test/scala/com/daml/projection/ProjectionSpec.scala
+++ b/src/test/scala/com/daml/projection/ProjectionSpec.scala
@@ -177,7 +177,7 @@ class ProjectionSpec
         import envelope._
         val actingParties = event.actingParties.mkString(",")
         val witnessParties = event.witnessParties.mkString(",")
-        List(ExecuteUpdate(s"""insert into ${table.name}
+        List(ExecuteUpdate(s"""insert into ${exercisedEventsProjectionTable.name}
           (contract_id, event_id, acting_parties, witness_parties, event_offset)
           values (:cid, :ap, :wp, :eid, :o)""")
           .bind("cid", event.contractId)
@@ -336,7 +336,7 @@ class ProjectionSpec
         import envelope._
         val actingParties = event.actingParties.mkString(",")
         val witnessParties = event.witnessParties.mkString(",")
-        List(ExecuteUpdate(s"""insert into ${table.name}
+        List(ExecuteUpdate(s"""insert into ${exercisedEventsProjectionTable.name}
           (contract_id, event_id, acting_parties, witness_parties, event_offset)
           values (:cid, :ap, :wp, :eid, :o)""")
           .bind("cid", event.contractId)
@@ -437,7 +437,8 @@ class ProjectionSpec
         import envelope._
         val c = event
         val witnessParties = c.event.witnessParties.mkString(",")
-        List(ExecuteUpdate(s"""insert into ${table.name} (contract_id, event_id, witness_parties, amount, currency)
+        List(ExecuteUpdate(
+          s"""insert into ${iousProjectionTable.name} (contract_id, event_id, witness_parties, amount, currency)
       values (:cid, :eid, :wp, :a, :c)""")
           .bind("cid", c.iou.id.contractId)
           .bind("eid", c.event.eventId)
@@ -500,7 +501,8 @@ class ProjectionSpec
     val witnessParties = event.witnessParties.mkString(",")
     val iou = toIou(event)
 
-    List(ExecuteUpdate(s"""insert into ${table.name} (contract_id, event_id, witness_parties, amount, currency)
+    List(ExecuteUpdate(
+      s"""insert into ${iousProjectionTable.name} (contract_id, event_id, witness_parties, amount, currency)
       values (?, ?, ?, ?, ?)""")
       .bind(1, event.contractId)
       .bind(2, event.eventId)

--- a/src/test/scala/com/daml/projection/TestUtil.scala
+++ b/src/test/scala/com/daml/projection/TestUtil.scala
@@ -31,36 +31,31 @@ object TestUtil {
 
   val jTemplateId = com.daml.ledger.javaapi.data.Identifier.fromProto(Identifier.toJavaProto(templateId))
 
-  def eventsProjection(partyId: String) = {
-    val projectionId = ProjectionId(java.util.UUID.randomUUID().toString())
-    val projectionTable = ProjectionTable("ious")
+  val projectionId = ProjectionId(java.util.UUID.randomUUID().toString())
+  val iousProjectionTable = ProjectionTable("ious")
 
+  def eventsProjection(partyId: String) = {
     Projection[Event](
       projectionId,
-      ProjectionFilter.templateIdsByParty(Map(partyId -> Set(templateId))),
-      projectionTable
+      ProjectionFilter.templateIdsByParty(Map(partyId -> Set(templateId)))
     )
   }
-
   def iouProjection(partyId: String) = {
     val projectionId = ProjectionId(java.util.UUID.randomUUID().toString())
-    val projectionTable = ProjectionTable("ious")
 
     Projection[ContractAndEvent](
       projectionId,
-      ProjectionFilter.templateIdsByParty(Map(partyId -> Set(templateId))),
-      projectionTable
+      ProjectionFilter.templateIdsByParty(Map(partyId -> Set(templateId)))
     )
   }
 
+  val exercisedEventsProjectionTable = ProjectionTable("exercised_events")
   def mkChoice(partyId: String) = {
     val projectionId = ProjectionId(java.util.UUID.randomUUID().toString())
-    val projectionTable = ProjectionTable("exercised_events")
 
     Projection[ExercisedEvent](
       projectionId,
-      ProjectionFilter.parties(Set(partyId)),
-      projectionTable
+      ProjectionFilter.parties(Set(partyId))
     )
   }
 

--- a/src/test/scala/com/daml/projection/javadsl/JavaApiSpec.scala
+++ b/src/test/scala/com/daml/projection/javadsl/JavaApiSpec.scala
@@ -59,17 +59,16 @@ class JavaApiSpec
       )
       val batchSource = BatchSource.create(JList.of(batch))
       val projector = JdbcProjector.create(ds, system)
-
+      val projectionTable = ProjectionTable("ious")
       val projection = Projection.create[Event](
         projectionId,
-        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-        iousProjectionTable
+        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
       )
       When("projecting created events")
       val control = projector.project(
         batchSource,
         projection.withEndOffset(offsets.last).withBatchSize(1),
-        insertCreateEvent
+        insertCreateEvent(projectionTable)
       )
       // projecting up to an offset, when it is reached the projection stops automatically
       control.resourcesClosed().asScala.futureValue mustBe Done
@@ -99,14 +98,13 @@ class JavaApiSpec
 
       val projection = Projection.create[Event](
         projectionId,
-        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-        projectionTable
+        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
       )
       When("projecting created events")
       val control = projector.project(
         BatchSource.events(clientSettings),
         projection.withEndOffset(Offset(last.completionOffset)).withBatchSize(1),
-        insertCreateEvent
+        insertCreateEvent(projectionTable)
       )
       // projecting up to an offset, when it is reached the projection stops automatically
       control.resourcesClosed().asScala.futureValue mustBe Done
@@ -141,15 +139,14 @@ class JavaApiSpec
 
       val projection = Projection.create[Iou.Contract](
         projectionId,
-        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-        projectionTable
+        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
       )
 
       Given("An UpdateMany batch operation")
       val updateMany =
         UpdateMany.create(
           Sql
-            .binder[Iou.Contract](s"""|insert into ${projection.table.name} 
+            .binder[Iou.Contract](s"""|insert into ${projectionTable.name} 
                 |(
                 |  contract_id, 
                 |  event_id, 
@@ -213,8 +210,7 @@ class JavaApiSpec
       val projection = Projection
         .create[Iou.Contract](
           projectionId,
-          ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-          projectionTable
+          ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
         )
         .withEndOffset(Offset(last.completionOffset))
 
@@ -227,7 +223,7 @@ class JavaApiSpec
       val control = projector.project[Iou.Contract](
         BatchSource.create(clientSettings, mkContract),
         projection.withBatchSize(1),
-        insertIou
+        insertIou(projectionTable)
       )
       // projecting up to an offset, when it is reached the projection stops automatically
       control.resourcesClosed().asScala.futureValue mustBe Done
@@ -258,8 +254,7 @@ class JavaApiSpec
       val projection = Projection
         .create[Event](
           projectionId,
-          ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-          projectionTable
+          ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
         )
         .withEndOffset(Offset(created.completionOffset))
 
@@ -267,7 +262,7 @@ class JavaApiSpec
       val control = projector.project(
         BatchSource.events(clientSettings),
         projection.withBatchSize(1),
-        insertOrDelete
+        insertOrDelete(projectionTable)
       )
 
       // projecting up to an offset, when it is reached the projection stops automatically
@@ -282,7 +277,7 @@ class JavaApiSpec
       val controlAfter = projector.project(
         BatchSource.events(clientSettings),
         projection.withEndOffset(Offset(createdAfterArchive.completionOffset)).withBatchSize(1),
-        insertOrDelete
+        insertOrDelete(projectionTable)
       )
       // projecting up to an offset, when it is reached the projection stops automatically
       controlAfter.resourcesClosed().asScala.futureValue mustBe Done
@@ -310,13 +305,12 @@ class JavaApiSpec
 
       val projection = Projection.create[Event](
         projectionId,
-        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-        projectionTable
+        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
       )
 
       When("projecting events")
       val control =
-        projector.project(BatchSource.events(clientSettings), projection, insertOrDelete)
+        projector.project(BatchSource.events(clientSettings), projection, insertOrDelete(projectionTable))
 
       Then("eventually the projected table should contain the events")
       eventually(timeout(Span(5, Seconds))) {
@@ -325,7 +319,6 @@ class JavaApiSpec
       }
       control.cancel().asScala.futureValue
       control.resourcesClosed().asScala.futureValue mustBe Done
-
     }
 
     "project exercised events" in {
@@ -348,15 +341,14 @@ class JavaApiSpec
       Given("an ExercisedEvents projection")
       val projection = Projection[ExercisedEvent](
         projectionId,
-        ProjectionFilter.parties(Set(alice)),
-        projectionTable
+        ProjectionFilter.parties(Set(alice))
       ).withPredicate(choice(alice))
 
       val projector = JdbcProjector.create(ds, system)
       val control = projector.project(
         BatchSource.exercisedEvents(clientSettings),
         projection.withEndOffset(Offset(exercised.completionOffset)).withBatchSize(1),
-        insertExercisedTransfer
+        insertExercisedTransfer(projectionTable)
       )
 
       // projecting up to an offset, when it is reached the projection stops automatically
@@ -389,15 +381,14 @@ class JavaApiSpec
 
       val projection = Projection.create[Event](
         projectionId,
-        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-        projectionTable
+        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
       )
 
       When("projecting events")
       val control = projector.project(
         BatchSource.events(clientSettings),
         projection.withEndOffset(Offset(created.completionOffset)).withBatchSize(1),
-        insertOrDelete
+        insertOrDelete(projectionTable)
       )
 
       // projecting up to an offset, when it is reached the projection stops automatically
@@ -416,7 +407,7 @@ class JavaApiSpec
       val controlAfter = projector.project(
         BatchSource.events(clientSettings),
         projection.withEndOffset(Offset(createdNext.completionOffset)).withBatchSize(1),
-        insertOrDelete
+        insertOrDelete(projectionTable)
       )
 
       controlAfter.resourcesClosed().asScala.futureValue mustBe Done
@@ -453,15 +444,14 @@ class JavaApiSpec
 
       val projection = Projection.create[TreeEvent](
         projectionId,
-        ProjectionFilter.parties(Set(alice).asJava),
-        projectionTable
+        ProjectionFilter.parties(Set(alice).asJava)
       )
 
       When("projecting events")
       val control = projector.project(
         BatchSource.treeEvents(clientSettings),
         projection.withEndOffset(Offset(exercised.completionOffset)).withBatchSize(1),
-        insertTreeTransfer
+        insertTreeTransfer(projectionTable)
       )
       // projecting up to an offset, when it is reached the projection stops automatically
       control.resourcesClosed().asScala.futureValue mustBe Done
@@ -485,7 +475,6 @@ class JavaApiSpec
     "stop the projection process and fail when an exception occurs in a JdbcAction" in {
       val alice = uniqueParty("Alice")
       val projectionId = ProjectionId(java.util.UUID.randomUUID().toString())
-      val projectionTable = ProjectionTable("ious")
 
       Given("created contracts")
       createIou(alice, alice, 1d).futureValue
@@ -494,8 +483,7 @@ class JavaApiSpec
 
       val projection = Projection.create[Event](
         projectionId,
-        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-        projectionTable
+        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
       )
       val failingSql: Project[Event, JdbcAction] = { _ =>
         JList.of(ExecuteUpdate("insert into blabla"))
@@ -517,14 +505,12 @@ class JavaApiSpec
     "stop the projection process and fail when using bad grpc settings" in {
       val alice = uniqueParty("Alice")
       val projectionId = ProjectionId(java.util.UUID.randomUUID().toString())
-      val projectionTable = ProjectionTable("ious")
 
       val projector = JdbcProjector.create(ds, system)
 
       val projection = Projection.create[Event](
         projectionId,
-        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-        projectionTable
+        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
       )
       val failingSql: Project[Event, JdbcAction] = { _ =>
         JList.of(ExecuteUpdate.create("insert into blabla"))
@@ -567,17 +553,16 @@ class JavaApiSpec
       }
       val batchSource = BatchSource.create(batches.asJava)
       val projector = JdbcProjector.create(ds, system)
-
+      val projectionTable = ProjectionTable("ious")
       val projection = Projection.create[Event](
         projectionId,
-        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava),
-        iousProjectionTable
+        ProjectionFilter.templateIdsByParty(Map(alice -> Set(jTemplateId).asJava).asJava)
       )
       When("projecting created events")
       val control = projector.project(
         batchSource,
         projection.withEndOffset(Offset(f"${size - 1}%07d")),
-        insertCreateEvent
+        insertCreateEvent(projectionTable)
       )
       // projecting up to an offset, when it is reached the projection stops automatically
       control.resourcesClosed().asScala.futureValue mustBe Done
@@ -629,12 +614,11 @@ class JavaApiSpec
       None.toJava,
       None.toJava,
       None.toJava,
-      Some(offset).toJava,
-      iousProjectionTable
+      Some(offset).toJava
     )
   }
 
-  val insertCreateEvent: Project[Event, JdbcAction] = { envelope: Envelope[Event] =>
+  def insertCreateEvent(table: ProjectionTable): Project[Event, JdbcAction] = { envelope: Envelope[Event] =>
     import envelope._
     val witnessParties = event.getWitnessParties().asScala.toList.mkString(",")
     // Java usage
@@ -669,7 +653,7 @@ class JavaApiSpec
     }
   }
 
-  val insertIou: Project[Iou.Contract, JdbcAction] = { envelope: Envelope[Iou.Contract] =>
+  def insertIou(table: ProjectionTable): Project[Iou.Contract, JdbcAction] = { envelope: Envelope[Iou.Contract] =>
     import envelope._
     val contract = unwrap
     val iou = contract.data
@@ -693,7 +677,7 @@ class JavaApiSpec
     )
   }
 
-  val insertOrDelete: Project[Event, JdbcAction] = { envelope: Envelope[Event] =>
+  def insertOrDelete(table: ProjectionTable): Project[Event, JdbcAction] = { envelope: Envelope[Event] =>
     import envelope._
     val witnessParties = event.getWitnessParties().asScala.toList.mkString(",")
     // Java usage
@@ -713,7 +697,7 @@ class JavaApiSpec
     } else if (event.isInstanceOf[ArchivedEvent]) {
       val archivedEvent = event.asInstanceOf[ArchivedEvent]
       JList.of[JdbcAction](
-        ExecuteUpdate(s"""delete from ${table.name} where contract_id = ?""")
+        ExecuteUpdate(s"""delete from ${iousProjectionTable.name} where contract_id = ?""")
           .bind(1, archivedEvent.getContractId())
       )
     } else {
@@ -721,7 +705,7 @@ class JavaApiSpec
     }
   }
 
-  val insertExercisedTransfer: Project[ExercisedEvent, JdbcAction] = {
+  def insertExercisedTransfer(table: ProjectionTable): Project[ExercisedEvent, JdbcAction] = {
     envelope: Envelope[ExercisedEvent] =>
       import envelope._
       val actingParties = event.getActingParties.asScala.mkString(",")
@@ -747,7 +731,7 @@ class JavaApiSpec
       } else JList.of()
   }
 
-  val insertTreeTransfer: Project[TreeEvent, JdbcAction] = { envelope: Envelope[TreeEvent] =>
+  def insertTreeTransfer(table: ProjectionTable): Project[TreeEvent, JdbcAction] = { envelope: Envelope[TreeEvent] =>
     import envelope._
     val witnessParties = event.getWitnessParties.asScala.mkString(",")
     event match {

--- a/src/test/scala/com/daml/projection/javadsl/JdbcPerfSpec.scala
+++ b/src/test/scala/com/daml/projection/javadsl/JdbcPerfSpec.scala
@@ -41,13 +41,14 @@ class JdbcPerfSpec
       val nrEventsPerTx = 10000
       val generatedSize = nrTxs * nrEventsPerTx
       val lastOffset = Offset(f"offset-$nrTxs%07d")
+      val projectionTable = ProjectionTable("exercised_events")
       val projection: Projection[ExercisedEvent] = mkChoice
         .withEndOffset(lastOffset)
       projector.getOffset(projection) must be(None)
 
       println("Preparing events")
 
-      def mkEvent(ix: Int, txId: String, projection: Projection[ExercisedEvent], offset: Offset) =
+      def mkEvent(ix: Int, txId: String, offset: Offset) =
         Envelope(
           ExercisedEvent(
             eventId = "event-id-" + ix,
@@ -63,15 +64,14 @@ class JdbcPerfSpec
           None,
           None,
           Some(txId),
-          Some(offset),
-          projection.table
+          Some(offset)
         )
 
       def mkTx(tx: Int): Seq[ConsumerRecord[ExercisedEvent]] = {
         val txId = f"tx-$tx%07d"
         val offset = Offset(f"offset-$tx%07d")
         (1 to nrEventsPerTx).map { ePerTx =>
-          mkEvent(ePerTx, txId, projection, offset)
+          mkEvent(ePerTx, txId, offset)
         } ++ List(TxBoundary(projection.id, offset))
       }
 
@@ -103,7 +103,7 @@ class JdbcPerfSpec
         batchSource,
         projection,
         UpdateMany.create(
-          Sql.binder[ExercisedEventRow](s"insert into ${projection.table.name}(contract_id, event_id, acting_parties, witness_parties, event_offset) VALUES (?, ?, ?, ?, ?)")
+          Sql.binder[ExercisedEventRow](s"insert into ${projectionTable.name}(contract_id, event_id, acting_parties, witness_parties, event_offset) VALUES (?, ?, ?, ?, ?)")
             .bind(1, _.contractId)
             .bind(2, _.eventId)
             .bind(3, _.actingParties)
@@ -151,7 +151,7 @@ class JdbcPerfSpec
       val size = tableSize.split(" ")(0)
       val MB = tableSize.split(" ")(1)
       MB must be("MB")
-      println(s"${projection.table} size= $tableSize")
+      println(s"${projectionTable} size= $tableSize")
       val eventSizeK = size.toDouble * 1024 / generatedSize
       println(s"size of an event =~ ${eventSizeK}k, expecting more than ${10000d / eventSizeK} ops/sec")
       opsSec must be.>(10000d / eventSizeK)
@@ -165,16 +165,12 @@ class JdbcPerfSpec
   )
   val choice = "IouTransfer_Accept"
   val partyIdBob = "Bob::1220ca5c20e3d9e47ade773119246e250f5384765d5302d3b37d21de7e0c07fd3d55"
+  val projectionId = ProjectionId("id-1")
 
   def mkChoice = {
-    val projectionId = ProjectionId("id-1")
-
-    val projectionTable = ProjectionTable("exercised_events")
-
     Projection[ExercisedEvent](
       projectionId,
-      ProjectionFilter.parties(Set(partyIdBob)),
-      projectionTable
+      ProjectionFilter.parties(Set(partyIdBob))
     )
   }
   case class ExercisedEventRow(

--- a/src/test/scala/com/daml/projectiontest/FacadeSpec.scala
+++ b/src/test/scala/com/daml/projectiontest/FacadeSpec.scala
@@ -82,7 +82,7 @@ class FacadeSpec
           "contract_id",
           event.contractId))
       }
-      val f = Projection.fromCreateOrArchive(insert, delete)
+      val f = Projection.fromCreatedOrArchived(insert, delete)
       implicit val source = BatchSource.events(clientSettings)
       val ctrl = Projection.project(source, events)(f)
       ctrl.cancel().map(_ mustBe Done)


### PR DESCRIPTION
- A `Projection` can project to many tables, so it did not seem very useful to have one projection table required for the `Projection`.
- Initially there was an idea to validate a projection from projection table columns, and to create your own projection types, but this did not really work out well, so the columns are removed that were used for this.
- circe was used for custom projection persistence and projection validation, not needed anymore so the dependency could be removed.