### PR TITLE
Bind typeclass.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,8 @@ val deps = Seq(
   "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
   "org.flywaydb" % "flyway-core" % "8.5.11",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.4",
+  "org.slf4j" % "slf4j-api" % "2.0.5",
+  "ch.qos.logback" % "logback-classic" % "1.3.5",
   "com.zaxxer" % "HikariCP" % "5.0.1" % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
   "org.scalatest" %% "scalatest-core" % ScalaTestVersion % Test,

--- a/src/main/scala/com/daml/projection/JdbcAction.scala
+++ b/src/main/scala/com/daml/projection/JdbcAction.scala
@@ -214,8 +214,6 @@ object Bind {
   implicit val Instant: Bind[Instant] =
     mkN((ps, pos, x) => ps.setTimestamp(pos, new java.sql.Timestamp(x.toEpochMilli)))
   implicit val Array: Bind[java.sql.Array] = mkN(_.setArray(_, _))
-  implicit val Null: Bind[Null] = mkN((ps, pos, _) => ps.setNull(pos, java.sql.Types.NULL))
-  // TODO SC is Types.NULL right?
 
   implicit val Offset: Bind[Offset] = mkN((ps, pos, x) => ps.setString(pos, x.value))
   implicit val ProjectionId: Bind[ProjectionId] = mkN((ps, pos, x) => ps.setString(pos, x.value))
@@ -303,7 +301,7 @@ object Binder {
 /**
  * Binds fields of `R` to a `PreparedStatement`.
  * @tparam R
- *   the type from which Setters are mapped.
+ *   the type from which [[Bind]]s are created.
  */
 final case class Binder[R](
     sql: Sql.Statement,

--- a/src/main/scala/com/daml/projection/JdbcAction.scala
+++ b/src/main/scala/com/daml/projection/JdbcAction.scala
@@ -196,15 +196,24 @@ object Bind {
     // TODO SC would a specific thing from Types be better?
   }
 
-  implicit val Boolean: Bind[Boolean] = mk(_.setBoolean(_, _))
-  implicit val Byte: Bind[Byte] = mk(_.setByte(_, _))
-  implicit val Short: Bind[Short] = mk(_.setShort(_, _))
-  implicit val Int: Bind[Int] = mk(_.setInt(_, _))
-  implicit val Long: Bind[Long] = mk(_.setLong(_, _))
-  implicit val Float: Bind[Float] = mk(_.setFloat(_, _))
-  implicit val Double: Bind[Double] = mk(_.setDouble(_, _))
-  implicit val `scala BigDecimal`: Bind[BigDecimal] = mkN((ps, pos, x) => ps.setBigDecimal(pos, x.bigDecimal))
+  implicit val Boolean: Bind[java.lang.Boolean] = mkN((ps, pos, x) => ps.setBoolean(pos, x.booleanValue()))
+  implicit val Byte: Bind[java.lang.Byte] = mkN((ps, pos, x) => ps.setByte(pos, x.toByte))
+  implicit val Short: Bind[java.lang.Short] = mkN((ps, pos, x) => ps.setShort(pos, x.toShort))
+  implicit val Int: Bind[java.lang.Integer] = mkN((ps, pos, x) => ps.setInt(pos, x.toInt))
+  implicit val Long: Bind[java.lang.Long] = mkN((ps, pos, x) => ps.setLong(pos, x.toLong))
+  implicit val Float: Bind[java.lang.Float] = mkN((ps, pos, x) => ps.setFloat(pos, x.toFloat))
+  implicit val Double: Bind[java.lang.Double] = mkN((ps, pos, x) => ps.setDouble(pos, x.toDouble))
   implicit val BigDecimal: Bind[java.math.BigDecimal] = mkN(_.setBigDecimal(_, _))
+
+  implicit val _Boolean: Bind[Boolean] = mk(_.setBoolean(_, _))
+  implicit val _Byte: Bind[Byte] = mk(_.setByte(_, _))
+  implicit val _Short: Bind[Short] = mk(_.setShort(_, _))
+  implicit val _Int: Bind[Int] = mk(_.setInt(_, _))
+  implicit val _Long: Bind[Long] = mk(_.setLong(_, _))
+  implicit val _Float: Bind[Float] = mk(_.setFloat(_, _))
+  implicit val _Double: Bind[Double] = mk(_.setDouble(_, _))
+  implicit val _BigDecimal: Bind[BigDecimal] = mkN((ps, pos, x) => ps.setBigDecimal(pos, x.bigDecimal))
+
   implicit val String: Bind[String] = mkN(_.setString(_, _))
   implicit val Date: Bind[java.sql.Date] = mkN(_.setDate(_, _))
   implicit val LocalDate: Bind[LocalDate] = mkN((ps, pos, x) => ps.setDate(pos, java.sql.Date.valueOf(x)))

--- a/src/main/scala/com/daml/projection/JdbcAction.scala
+++ b/src/main/scala/com/daml/projection/JdbcAction.scala
@@ -5,13 +5,13 @@ package com.daml.projection
 
 import com.typesafe.scalalogging.LazyLogging
 
-import java.sql.SQLException
+import java.sql.{ PreparedStatement, SQLException }
+import java.time.{ Instant, LocalDate, LocalDateTime }
 import java.util.Optional
 import scala.jdk.CollectionConverters._
 import scala.util.control.NoStackTrace
 import scala.util.matching.Regex
 import scala.jdk.FunctionConverters._
-import java.{ util => ju }
 import java.util.{ function => juf }
 
 /**
@@ -93,33 +93,28 @@ object Sql {
       namedParameters: Map[String, Parameter],
       positionalParameters: List[Parameter],
       parameterNames: List[String],
-      setters: Map[Int, Setter] = Map.empty[Int, Setter]
+      binds: Map[Int, Bind.Applied] = Map.empty[Int, Bind.Applied]
   ) {
-    def totalParameters = namedParameters.size + positionalParameters.size
+    def parametersSize = namedParameters.size + positionalParameters.size
     def binder[R] = Binder[R](this)
+    def isBound = parametersSize == binds.size
 
     /**
      * Bind an argument to a parameter by position in the SQL query.
      */
-    def bind[T](pos: Int, arg: T): Statement = {
-      copy(setters = setters + (pos -> setter(pos, arg)))
-    }
+    def bind[T: Bind.Used](pos: Int, arg: T): Statement =
+      copy(binds = binds + (pos -> bindValue(pos, arg)))
 
-    def setter[T](pos: Int, arg: T): Setter = {
-      require(pos > 0, "bind position must be >= 1")
-      require(
-        pos <= totalParameters,
-        s"bind position '$pos', out of bounds for ${totalParameters} bind parameters"
-      )
-      require(!setters.contains(pos), s"cannot bind to the same position '$pos' more than once")
-      BindValue(arg, pos)
-    }
-
-    def setter[T](name: String, arg: T): Setter = {
+    /**
+     * Bind an argument to a named parameter. Parameters start with a colon ':' followed by a letter. Numbers,
+     * underscore and lowercase letters are allowed characters in a named parameter.
+     */
+    def bind[T: Bind.Used](name: String, arg: T): Statement = {
+      require(!name.startsWith(":"), s"cannot bind to name $name, must not start with ':'.")
       val delimiter = ", "
       namedParameters.get(name).map { namedParameter =>
-        require(!setters.contains(namedParameter.position), s"cannot bind to the same name '$name' more than once")
-        BindValue(arg, namedParameter.position)
+        require(!binds.contains(namedParameter.position), s"cannot bind to the same name '$name' more than once")
+        copy(binds = binds + (namedParameter.position -> bindValue(namedParameter.position, arg)))
       }.getOrElse {
         if (!namedParameters.isEmpty) throw new IllegalArgumentException(
           s"Cannot bind '$name'. sql statement:\n${originalSql}'\nbind parameters:\n${namedParameters.values.mkString(delimiter)}")
@@ -128,15 +123,24 @@ object Sql {
       }
     }
 
-    /**
-     * Bind an argument to a named parameter. Parameters start with a colon ':' followed by a letter. Numbers,
-     * underscore and lowercase letters are allowed characters in a named parameter.
-     */
-    def bind[T](name: String, arg: T): Statement = {
+    def bindValue[T: Bind.Used](pos: Int, arg: T): Bind.Applied = {
+      require(pos > 0, "bind position must be >= 1")
+      require(
+        pos <= parametersSize,
+        s"bind position '$pos', out of bounds for ${parametersSize} bind parameters"
+      )
+      require(!binds.contains(pos), s"cannot bind to the same position '$pos' more than once")
+      val setter = implicitly[Bind.Used[T]]
+      setter.apply(arg, pos)
+    }
+
+    def bindValue[T: Bind.Used](name: String, arg: T): Bind.Applied = {
+      val setter = implicitly[Bind.Used[T]]
+
       val delimiter = ", "
       namedParameters.get(name).map { namedParameter =>
-        require(!setters.contains(namedParameter.position), s"cannot bind to the same name '$name' more than once")
-        copy(setters = setters + (namedParameter.position -> BindValue(arg, namedParameter.position)))
+        require(!binds.contains(namedParameter.position), s"cannot bind to the same name '$name' more than once")
+        setter.apply(arg, namedParameter.position)
       }.getOrElse {
         if (!namedParameters.isEmpty) throw new IllegalArgumentException(
           s"Cannot bind '$name'. sql statement:\n${originalSql}'\nbind parameters:\n${namedParameters.values.mkString(delimiter)}")
@@ -162,42 +166,69 @@ object Sql {
 }
 
 /**
- * Binds a value to a position in the PreparedStatement.
+ * Binds a value of `T` to a [[java.sql.PreparedStatement]].
  */
-final case class BindValue[T](value: T, pos: Int) extends Setter {
-  def set(ps: java.sql.PreparedStatement) = {
-    value match {
-      case x: Boolean                   => ps.setBoolean(pos, x)
-      case x: Byte                      => ps.setByte(pos, x)
-      case x: Short                     => ps.setShort(pos, x)
-      case x: Int                       => ps.setInt(pos, x)
-      case x: Long                      => ps.setLong(pos, x)
-      case x: Float                     => ps.setFloat(pos, x)
-      case x: Double                    => ps.setDouble(pos, x)
-      case x: BigDecimal                => ps.setBigDecimal(pos, x.bigDecimal)
-      case x: java.math.BigDecimal      => ps.setBigDecimal(pos, x)
-      case x: String                    => ps.setString(pos, x)
-      case x: java.sql.Date             => ps.setDate(pos, x)
-      case x: java.sql.Timestamp        => ps.setTimestamp(pos, x)
-      case x: java.sql.Array            => ps.setArray(pos, x)
-      case null                         => ps.setNull(pos, java.sql.Types.NULL)
-      case x: Optional[_] if x.isEmpty  => ps.setNull(pos, java.sql.Types.NULL)
-      case x: Optional[_] if !x.isEmpty => ps.setObject(pos, x.get())
-      // TODO fix in typeclass solution
-      case x: Option[_] if x.isEmpty => ps.setNull(pos, java.sql.Types.NULL)
-      case Some(x)                   => ps.setObject(pos, x)
-      case x                         => ps.setObject(pos, x)
-    }
-  }
+@FunctionalInterface
+trait Bind[-T] {
+
+  /** Sets the value on the [[java.sql.PreparedStatement]] */
+  def set(ps: PreparedStatement, pos: Int, value: T): Unit
+
+  /** Creates a [[Bind.Applied]] function that will set `value` at `pos` on a `PreparedStatement` argument. */
+  final def apply(value: T, pos: Int): Bind.Applied = set(_, pos, value)
 }
 
-/** Sets a bind value on a PreparedStatement */
-@SerialVersionUID(1L)
-@FunctionalInterface
-trait Setter extends java.io.Serializable {
+/**
+ * Provides `Bind` values for [[ExecuteUpdate.bind[T](pos*]],[[ExecuteUpdate.bind[T](name*]], [[Binder.bind[T](pos*]]
+ * and [[Binder.bind[T](name*]] methods.
+ */
+object Bind {
+  type Used[-T] = Bind[_ >: T]
 
-  /** Sets a bind value on `ps` */
-  def set(ps: java.sql.PreparedStatement): Unit
+  private def mk[T <: AnyVal](f: (PreparedStatement, Int, T) => Unit): Bind[T] = new Bind[T] {
+    override def set(ps: PreparedStatement, pos: Int, value: T) = f(ps, pos, value)
+  }
+
+  private def mkN[T >: Null <: AnyRef](f: (PreparedStatement, Int, T) => Unit): Bind[T] = new Bind[T] {
+    override def set(ps: PreparedStatement, pos: Int, value: T) = {
+      if (value eq null) ps.setNull(pos, java.sql.Types.NULL) else f(ps, pos, value)
+    }
+    // TODO SC would a specific thing from Types be better?
+  }
+
+  implicit val Boolean: Bind[Boolean] = mk(_.setBoolean(_, _))
+  implicit val Byte: Bind[Byte] = mk(_.setByte(_, _))
+  implicit val Short: Bind[Short] = mk(_.setShort(_, _))
+  implicit val Int: Bind[Int] = mk(_.setInt(_, _))
+  implicit val Long: Bind[Long] = mk(_.setLong(_, _))
+  implicit val Float: Bind[Float] = mk(_.setFloat(_, _))
+  implicit val Double: Bind[Double] = mk(_.setDouble(_, _))
+  implicit val `scala BigDecimal`: Bind[BigDecimal] = mkN((ps, pos, x) => ps.setBigDecimal(pos, x.bigDecimal))
+  implicit val BigDecimal: Bind[java.math.BigDecimal] = mkN(_.setBigDecimal(_, _))
+  implicit val String: Bind[String] = mkN(_.setString(_, _))
+  implicit val Date: Bind[java.sql.Date] = mkN(_.setDate(_, _))
+  implicit val LocalDate: Bind[LocalDate] = mkN((ps, pos, x) => ps.setDate(pos, java.sql.Date.valueOf(x)))
+  implicit val Timestamp: Bind[java.sql.Timestamp] = mkN(_.setTimestamp(_, _))
+  implicit val LocalDateTime: Bind[LocalDateTime] =
+    mkN((ps, pos, x) => ps.setTimestamp(pos, java.sql.Timestamp.valueOf(x)))
+  implicit val Instant: Bind[Instant] =
+    mkN((ps, pos, x) => ps.setTimestamp(pos, new java.sql.Timestamp(x.toEpochMilli)))
+  implicit val Array: Bind[java.sql.Array] = mkN(_.setArray(_, _))
+  implicit val Null: Bind[Null] = mkN((ps, pos, _) => ps.setNull(pos, java.sql.Types.NULL))
+  // TODO SC is Types.NULL right?
+
+  implicit val Offset: Bind[Offset] = mkN((ps, pos, x) => ps.setString(pos, x.value))
+  implicit val ProjectionId: Bind[ProjectionId] = mkN((ps, pos, x) => ps.setString(pos, x.value))
+
+  implicit def Optional[A](implicit setter: Bind.Used[A]): Bind[Optional[A]] =
+    mkN((ps, pos, x) => x.ifPresentOrElse(setter.set(ps, pos, _), () => ps.setNull(pos, java.sql.Types.NULL)))
+  implicit def Option[A](implicit setter: Bind.Used[A]): Bind[Option[A]] =
+    mkN((ps, pos, x) => x.map(setter.set(ps, pos, _)).getOrElse(ps.setNull(pos, java.sql.Types.NULL)))
+
+  // Java API
+  val Any: Bind[AnyRef] = mkN(_.setObject(_, _))
+
+  type Applied = PreparedStatement => Unit
 }
 
 /**
@@ -232,12 +263,11 @@ object ExecuteUpdate {
 final case class ExecuteUpdate(sql: Sql.Statement)
     extends JdbcAction
     with LazyLogging {
-  private val _setters = sql.setters.values.toList
-
+  private val binds = sql.binds.values.toList
   def execute(con: java.sql.Connection): Int = {
     val ps = con.prepareStatement(sql.jdbcStr)
     try {
-      _setters.foreach(_.set(ps))
+      binds.foreach(bind => bind(ps))
       ps.executeUpdate()
     } catch {
       case t: Throwable =>
@@ -251,13 +281,13 @@ final case class ExecuteUpdate(sql: Sql.Statement)
   /**
    * Bind an argument to a parameter by position in the SQL query.
    */
-  def bind[T](pos: Int, arg: T): ExecuteUpdate = copy(sql = sql.bind(pos, arg))
+  def bind[T: Bind.Used](pos: Int, arg: T): ExecuteUpdate = copy(sql = sql.bind(pos, arg))
 
   /**
-   * Bind an argument to a named parameter. Parameters start with a colon ':' numbers, underscore and lowercase letters
-   * are allowed characters in a named parameter.
+   * Bind an argument to a named parameter. In the SQL query, parameters start with a colon ':' numbers, underscore and
+   * lowercase letters are allowed characters in a named parameter. Provide `name` without ':' to this method.
    */
-  def bind[T](name: String, arg: T): ExecuteUpdate = copy(sql = sql.bind(name, arg))
+  def bind[T: Bind.Used](name: String, arg: T): ExecuteUpdate = copy(sql = sql.bind(name, arg))
 }
 
 /**
@@ -268,38 +298,46 @@ final case class SqlBindException(msg: String) extends Exception(msg) with NoSta
 
 object Binder {
   def create[R](sql: Sql.Statement): Binder[R] = Binder[R](sql)
-  def create[R](sql: Sql.Statement, binder: juf.Function[R, Setter]): Binder[R] = Binder[R](sql, List(binder.asScala))
-  def create[R](sql: Sql.Statement, binders: ju.List[juf.Function[R, Setter]]): Binder[R] =
-    Binder[R](sql, binders.asScala.map(_.asScala).toList)
 }
 
 /**
- * Transforms an `R` into a list of functions that creates [[Setter]]s from `R`.
+ * Binds fields of `R` to a `PreparedStatement`.
  * @tparam R
  *   the type from which Setters are mapped.
  */
-final case class Binder[R](sql: Sql.Statement, setterCreators: List[R => Setter] = List.empty[R => Setter]) {
-  private def bind(r: R => Setter): Binder[R] = {
-    copy(setterCreators = setterCreators :+ r)
+final case class Binder[R](
+    sql: Sql.Statement,
+    rowBinds: List[R => PreparedStatement => Unit] = List.empty[R => PreparedStatement => Unit]) {
+
+  private def bind[T: Bind.Used](pos: Int, field: R => T): Binder[R] = {
+    def setter(row: R): PreparedStatement => Unit = {
+      sql.bindValue(pos, field(row))
+    }
+    copy(rowBinds = rowBinds :+ setter)
   }
 
-  private def bind[T](pos: Int, field: R => T): Binder[R] = {
-    def setter(row: R) = sql.setter(pos, field(row))
-    copy(setterCreators = setterCreators :+ setter)
+  private def bind[T: Bind.Used](name: String, field: R => T): Binder[R] = {
+    require(!name.startsWith(":"), s"cannot bind to name $name, must not start with ':'.")
+    def setter(row: R): PreparedStatement => Unit = {
+      sql.bindValue(name, field(row))
+    }
+    copy(rowBinds = rowBinds :+ setter)
   }
 
-  private def bind[T](name: String, field: R => T): Binder[R] = {
-    def setter(row: R) = sql.setter(name, field(row))
-    copy(setterCreators = setterCreators :+ setter)
-  }
-
-  def bind[T](pos: Int, field: juf.Function[R, T]): Binder[R] =
+  /**
+   * Bind an argument to a parameter by position in the SQL query. The `field` function must extract a field from `R`
+   * that will be used as the argument for the parameter.
+   */
+  def bind[T: Bind.Used](pos: Int, field: juf.Function[R, T]): Binder[R] =
     bind(pos, field.asScala)
 
-  def bind[T](name: String, field: juf.Function[R, T]): Binder[R] =
+  /**
+   * Bind an argument to a named parameter. In the SQL query, parameters start with a colon ':' numbers, underscore and
+   * lowercase letters are allowed characters in a named parameter. Provide `name` without ':' to this method. The
+   * `field` function must extract a field from `R` that will be used as the argument for the parameter.
+   */
+  def bind[T: Bind.Used](name: String, field: juf.Function[R, T]): Binder[R] =
     bind(name, field.asScala)
-
-  def bind(r: juf.Function[R, Setter]): Binder[R] = bind(r.asScala)
 }
 
 /**
@@ -313,7 +351,8 @@ final case class ExecuteUpdateMany[R](sql: Sql.Statement, rows: Seq[R], binder: 
     try {
       rows.foreach { row =>
         ps.clearParameters()
-        binder.setterCreators.foreach(b => b(row).set(ps))
+
+        binder.rowBinds.foreach(set => set(row)(ps))
         ps.addBatch()
       }
       if (rows.nonEmpty) ps.executeBatch().toList.sum

--- a/src/main/scala/com/daml/projection/JdbcProjector.scala
+++ b/src/main/scala/com/daml/projection/JdbcProjector.scala
@@ -87,7 +87,9 @@ object JdbcProjector {
             |  where id = :id
           """.stripMargin
 
-        CommittedAction(ExecuteUpdate.create(sql).bind(1, offset.value).bind(2, projectionId.value))
+        CommittedAction(ExecuteUpdate.create(sql)
+          .bind(1, offset.value)
+          .bind(2, projectionId.value))
       }
     }
 

--- a/src/main/scala/com/daml/projection/Migration.scala
+++ b/src/main/scala/com/daml/projection/Migration.scala
@@ -9,7 +9,6 @@ import org.flywaydb.core.Flyway
 
 import javax.sql.DataSource
 import scala.jdk.CollectionConverters._
-import scala.util.Try
 
 private object Migration extends StrictLogging {
   def projectionTableName(implicit sys: ActorSystem) =
@@ -30,16 +29,14 @@ private object Migration extends StrictLogging {
       .locations(flywayLocations: _*)
       .load()
     if (migrateOnStart) {
-      Try {
+      try {
         flyway.validate()
-      }.recover { e =>
-        logger.trace(s"Flyway validation failed: ${e.getMessage}")
-        logger.trace(s"Attempting Flyway migration.")
-        Try {
+      } catch {
+        case e: Throwable =>
+          logger.trace(s"Flyway validation failed: ${e.getMessage}")
+          logger.trace(s"Attempting Flyway migration.")
           val result = flyway.migrate()
-          logger.trace(s"Flyway migration success: ${result.schemaName}")
-        }.recover(e => logger.error(s"Flyway migration failed.", e))
-        ()
+          logger.trace(s"Flyway executed ${result.migrationsExecuted} successfully in schema: ${result.schemaName}")
       }
     }
     0

--- a/src/main/scala/com/daml/projection/Offset.scala
+++ b/src/main/scala/com/daml/projection/Offset.scala
@@ -44,16 +44,6 @@ final case class ProjectionId(value: String) {
   def getValue(): String = value
 }
 
-final case class LedgerId(value: String) {
-
-  /**
-   * Java API
-   *
-   * Gets the value
-   */
-  def getValue(): String = value
-}
-
 /**
  * A SQL table that a [[Projection]] projects into
  */

--- a/src/test/java/com/daml/projectiontest/MyBigDecimal.java
+++ b/src/test/java/com/daml/projectiontest/MyBigDecimal.java
@@ -1,0 +1,12 @@
+// Copyright (c) 2022 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.daml.projectiontest;
+
+import java.math.BigDecimal;
+
+public class MyBigDecimal extends BigDecimal {
+  public MyBigDecimal(String val) {
+    super(val);
+  }
+}

--- a/src/test/resources/testdb/migration/V999__create_schema.sql
+++ b/src/test/resources/testdb/migration/V999__create_schema.sql
@@ -46,3 +46,20 @@ CREATE TABLE "java_api_tree_events"
   "witness_parties"             TEXT     NOT NULL,
   "event_offset"                TEXT     NOT NULL
 );
+
+CREATE TABLE "column_types_table"
+(
+  "contract_id"        TEXT      NULL,
+  "stakeholder"        TEXT      NOT NULL,
+  "long_column"        BIGINT    NULL,
+  "int_column"         INT       NULL,
+  "short_column"       SMALLINT  NULL,
+  "boolean_column"     BOOL      NULL,
+  "double_column"      FLOAT8    NULL,
+  "float_column"       FLOAT4    NULL,
+  "event_offset"       TEXT      NULL,
+  "projection_id"      TEXT      NULL,
+  "bigdecimal_column"  DECIMAL   NULL,
+  "date_column"        DATE      NULL,
+  "timestamp_column"   TIMESTAMPTZ NULL
+);

--- a/src/test/scala/com/daml/projection/ProjectionSpec.scala
+++ b/src/test/scala/com/daml/projection/ProjectionSpec.scala
@@ -170,7 +170,6 @@ class ProjectionSpec
       When("projecting exercised events")
       val source =
         Consumer.exercisedEventSource(clientSettings, projection.withBatchSize(1))
-
       // This is just for testing, one insert per envelope is VERY SLOW (obviously).
       // see PerfSpec and Action.bulkFlow
       val toAction: Projection.Project[ExercisedEvent, Action] = { envelope =>

--- a/src/test/scala/com/daml/projection/TestUtil.scala
+++ b/src/test/scala/com/daml/projection/TestUtil.scala
@@ -21,7 +21,6 @@ import com.daml.ledger.rxjava.DamlLedgerClient
 import com.daml.projection.IouContract.ContractAndEvent
 
 object TestUtil {
-  val ledgerId = LedgerId("default-ledger-id")
 
   val templateId = Identifier(
     packageId = Iou.TEMPLATE_ID.getPackageId(),
@@ -86,7 +85,6 @@ object TestUtil {
         Commands(
           party = issuer,
           applicationId = issuer,
-          ledgerId = ledgerId.value,
           commandId = java.util.UUID.randomUUID.toString,
           submissionId = java.util.UUID.randomUUID.toString,
           commands = commands
@@ -115,7 +113,6 @@ object TestUtil {
         Commands(
           party = party,
           applicationId = party,
-          ledgerId = ledgerId.value,
           commandId = java.util.UUID.randomUUID.toString,
           submissionId = java.util.UUID.randomUUID.toString,
           commands = Seq(cmd)
@@ -166,7 +163,6 @@ object TestUtil {
         Commands(
           party = issuer,
           applicationId = issuer,
-          ledgerId = ledgerId.value,
           commandId = java.util.UUID.randomUUID.toString,
           commands = commands
         )

--- a/src/test/scala/com/daml/projection/javadsl/JavaApiSpec.scala
+++ b/src/test/scala/com/daml/projection/javadsl/JavaApiSpec.scala
@@ -814,7 +814,7 @@ class JavaApiSpec
         )
         .bind(1, contract.id.contractId)
         .bind(2, "")
-        .bind(3, null)(Bind.Null)
+        .bind(3, null)(Bind.String)
         .bind(4, iou.amount)
         .bind(5, iou.currency)
     )

--- a/src/test/scala/com/daml/projection/javadsl/JavaApiSpec.scala
+++ b/src/test/scala/com/daml/projection/javadsl/JavaApiSpec.scala
@@ -814,7 +814,7 @@ class JavaApiSpec
         )
         .bind(1, contract.id.contractId)
         .bind(2, "")
-        .bind(3, null)(Bind.String)
+        .bind(3, null: String)
         .bind(4, iou.amount)
         .bind(5, iou.currency)
     )

--- a/src/test/scala/com/daml/projection/javadsl/JavaApiSpec.scala
+++ b/src/test/scala/com/daml/projection/javadsl/JavaApiSpec.scala
@@ -21,7 +21,7 @@ import org.scalatest.concurrent.Eventually.eventually
 import java.sql.SQLException
 import java.time.{ Instant, LocalDate, ZoneId }
 import java.time.temporal.ChronoUnit
-import java.util.{ List => JList }
+import java.util.{ List => JList, Optional }
 import scala.jdk.CollectionConverters._
 import scala.jdk.FunctionConverters._
 import scala.jdk.FutureConverters._
@@ -687,7 +687,11 @@ class JavaApiSpec
         records.asJava,
         TxBoundary.create[Record](projectionId, offsets.last)
       )
-      val batchSource = BatchSource.create(JList.of(batch))
+      val batchSource =
+        BatchSource.create(
+          JList.of(batch),
+          (_: Record) => Optional.empty[Identifier](),
+          (_: Record) => Set.empty[String].asJava)
       val projector = JdbcProjector.create(ds, system)
       val projectionTable = ProjectionTable("column_types_table")
       val projection = Projection.create[Record](


### PR DESCRIPTION
Fixes https://github.com/digital-asset/daml/issues/15705

Java API now requires to pass in a `Bind.X()` where `X` is the type to bind. Scala API gets these implicitly.